### PR TITLE
Fix popup localization setup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -28,16 +28,6 @@
     <h2 id="extensionName"></h2>
     <p id="extensionDescription"></p>
     <button id="fortuneButton"></button>
-    <script>
-        // ブラウザの言語設定を取得して、lang属性を設定する
-        console.log("Current browser language: ", navigator.language);
-        document.documentElement.lang = navigator.language.startsWith('ja') ? 'ja' : 'en';
-
-        // ローカライズメッセージの適用
-        document.getElementById('extensionName').innerText = chrome.i18n.getMessage('extension_name');
-        document.getElementById('extensionDescription').innerText = chrome.i18n.getMessage('short_description');
-        document.getElementById('fortuneButton').innerText = chrome.i18n.getMessage('fortune_button_label');
-    </script>
     <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,7 +1,12 @@
 document.addEventListener('DOMContentLoaded', function() {
+    console.log("Current browser language: ", navigator.language);
+    document.documentElement.lang = navigator.language.startsWith('ja') ? 'ja' : 'en';
+
     // ローカライズメッセージの適用
-    document.getElementById('extensionName').innerText = chrome.i18n.getMessage('extension_name');
-    document.getElementById('extensionDescription').innerText = chrome.i18n.getMessage('extension_description');
+    const extensionNameMessage = chrome.i18n.getMessage('extension_name');
+    document.title = extensionNameMessage;
+    document.getElementById('extensionName').innerText = extensionNameMessage;
+    document.getElementById('extensionDescription').innerText = chrome.i18n.getMessage('short_description');
     document.getElementById('fortuneButton').innerText = chrome.i18n.getMessage('fortune_button_label');
 
     // ボタンの機能


### PR DESCRIPTION
## Summary
- centralize the popup localization logic in popup.js, including setting the document language and title
- populate the popup description with the existing short_description message and remove duplicate inline scripting from popup.html

## Testing
- not run (extension manual testing required)


------
https://chatgpt.com/codex/tasks/task_e_68ca314892b883248d738f1859f6f70a