### PR TITLE
Add donation message to popup

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -31,5 +31,14 @@
   },
   "fortune_bottom_1": {
     "message": "Bottom 1%: Terrible luck!!"
+  },
+  "donation_message": {
+    "message": "If this extension has been helpful, I'd be grateful for your support—the price of a cup of coffee is enough! ☕"
+  },
+  "donation_link_text": {
+    "message": "Buy Me a Coffee"
+  },
+  "donation_link_url": {
+    "message": "https://buymeacoffee.com/hiroshiman"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -31,5 +31,14 @@
     },
     "fortune_bottom_1": {
       "message": "下位1%：大凶！！"
+    },
+    "donation_message": {
+      "message": "もしこの拡張機能が役に立ったら、コーヒー1杯分の応援をいただけると嬉しいです ☕"
+    },
+    "donation_link_text": {
+      "message": "Buy Me a Coffee"
+    },
+    "donation_link_url": {
+      "message": "https://buymeacoffee.com/hiroshiman"
     }
   }

--- a/popup.html
+++ b/popup.html
@@ -27,6 +27,8 @@
 <body>
     <h2 id="extensionName"></h2>
     <p id="extensionDescription"></p>
+    <p id="donationMessage"></p>
+    <a id="donationLink" href="#" target="_blank" rel="noopener noreferrer"></a>
     <button id="fortuneButton"></button>
     <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -9,6 +9,26 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('extensionDescription').innerText = chrome.i18n.getMessage('short_description');
     document.getElementById('fortuneButton').innerText = chrome.i18n.getMessage('fortune_button_label');
 
+    const donationMessageElement = document.getElementById('donationMessage');
+    donationMessageElement.textContent = chrome.i18n.getMessage('donation_message');
+
+    const donationLink = document.getElementById('donationLink');
+    const donationLinkUrl = chrome.i18n.getMessage('donation_link_url');
+    donationLink.innerText = chrome.i18n.getMessage('donation_link_text');
+    donationLink.href = donationLinkUrl;
+
+    donationMessageElement.appendChild(document.createTextNode(' '));
+    donationMessageElement.appendChild(donationLink);
+
+    donationLink.addEventListener('click', function(event) {
+        event.preventDefault();
+        if (typeof chrome !== 'undefined' && chrome.tabs && typeof chrome.tabs.create === 'function') {
+            chrome.tabs.create({ url: donationLinkUrl });
+        } else {
+            window.open(donationLinkUrl, '_blank');
+        }
+    });
+
     // ボタンの機能
     const fortuneButton = document.getElementById('fortuneButton');
     fortuneButton.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- add localized donation message and link strings for English and Japanese
- render the donation message in the popup and open the support link in a new tab

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca44cff1e08324b4e43aa0560aa9de