### PR TITLE
Update extension icons

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,18 @@
     "name": "__MSG_extension_name__",
     "version": "1.0",
     "description": "__MSG_full_description__",
+    "icons": {
+      "16": "icon_16.png",
+      "48": "icon_48.png",
+      "128": "icon.png"
+    },
     "action": {
       "default_popup": "popup.html",
-      "default_icon": "icon.png"
+      "default_icon": {
+        "16": "icon_16.png",
+        "48": "icon_48.png",
+        "128": "icon.png"
+      }
     },
     "content_scripts": [
         {


### PR DESCRIPTION
## Summary
- register the 16px, 48px, and 128px icons for the extension
- point the browser action icon to the new multi-size icon set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca7fd387448324bd4adea0b1e66fea